### PR TITLE
Add jpegtran optimization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Imager is a plugin for doing image transforms in Craft templates. It does all th
 - A convenient syntax for doing a bunch of image transforms in one go.  
 - Transforms are completely file-based, no database queries needed.
 - Transformed images are placed in their own folder, outside of the asset source folder.
-- Optimize your created images automatically with jpegoptim, optipng or TinyPNG.
+- Optimize your created images automatically with jpegoptim, jpegtran, optipng or TinyPNG.
 - Crop position is relative (in percent) not confined to edges/center (but the built-in keywords still works).  
 `{ width: 600, height: 600, mode: 'crop', position: '20% 65%' }`
 - New cropZoom parameter for when you want to get a little closer.  

--- a/imager/config.php
+++ b/imager/config.php
@@ -24,6 +24,10 @@ return array(
 	'jpegoptimPath' => '/usr/bin/jpegoptim',
 	'jpegoptimOptionString' => '-s',
 	
+	'jpegtranEnabled' => false,
+	'jpegtranPath' => '/usr/bin/jpegtran',
+	'jpegtranOptionString' => '-optimize -copy none',
+	
 	'optipngEnabled' => false,
 	'optipngPath' => '/usr/bin/optipng',
 	'optipngOptionString' => '-o5',

--- a/imager/models/Imager_ConfigModel.php
+++ b/imager/models/Imager_ConfigModel.php
@@ -41,6 +41,10 @@ class Imager_ConfigModel extends BaseModel
 			'jpegoptimPath'  					=> array(AttributeType::String),
 			'jpegoptimOptionString'  	=> array(AttributeType::String),
 			
+			'jpegtranEnabled'  			=> array(AttributeType::Bool),
+			'jpegtranPath'  					=> array(AttributeType::String),
+			'jpegtranOptionString'  	=> array(AttributeType::String),
+			
 			'optipngEnabled'  				=> array(AttributeType::Bool),
 			'optipngPath'  						=> array(AttributeType::String),
 			'optipngOptionString'  		=> array(AttributeType::String),

--- a/imager/services/ImagerService.php
+++ b/imager/services/ImagerService.php
@@ -274,6 +274,9 @@ class ImagerService extends BaseApplicationComponent
         if (($targetExtension=='jpg' || $targetExtension=='jpeg') && $this->getSetting('jpegoptimEnabled', $transform)) {
           $this->runJpegoptim($targetFilePath, $transform);
         }
+        if (($targetExtension=='jpg' || $targetExtension=='jpeg') && $this->getSetting('jpegtranEnabled', $transform)) {
+          $this->runJpegtran($targetFilePath, $transform);
+        }
         if ($targetExtension=='png' && $this->getSetting('optipngEnabled', $transform)) {
           $this->runOptipng($targetFilePath, $transform);
         }
@@ -841,6 +844,24 @@ class ImagerService extends BaseApplicationComponent
     $cmd .= ' ';
     $cmd .= $file;
     
+    $this->executeOptimize($cmd, $file);
+  }
+
+  /**
+   * Run jpegtran on file
+   *
+   * @param $file
+   * @param $transform
+   */
+  private function runJpegtran($file, $transform) {
+    $cmd = $this->getSetting('jpegtranPath', $transform);
+    $cmd .= ' ';
+    $cmd .= $this->getSetting('jpegtranOptionString', $transform);
+    $cmd .= ' -outfile ';
+    $cmd .= $file;
+    $cmd .= ' ';
+    $cmd .= $file;
+
     $this->executeOptimize($cmd, $file);
   }
   


### PR DESCRIPTION
Andre,

I added support for the jpegtran optimization library, which appears to give dramatically lower file sizes compared with jpegoptim in my (admittedly limited) testing. Like, anywhere from 65% to 1.5% of what they were with jpegoptim.

Thanks for putting this plugin out there!
-Eli