### PR TITLE
Added the option to remove Image Metadata for Imagick Driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/imager/config.php
+++ b/imager/config.php
@@ -45,6 +45,7 @@ return array(
   'awsBucket' => '',
   'awsCacheDuration' => 1209600, // 14 days
   'awsRequestHeaders' => array(),
-  'awsStorageType' => 'standard', // 'standard' or 'rrs' (reduced redundancy storage) 
+  'awsStorageType' => 'standard', // 'standard' or 'rrs' (reduced redundancy storage)
+  'removeMetadata' => false
   
 );

--- a/imager/models/Imager_ConfigModel.php
+++ b/imager/models/Imager_ConfigModel.php
@@ -65,6 +65,7 @@ class Imager_ConfigModel extends BaseModel
           'awsCacheDuration' => array(AttributeType::Number),
           'awsRequestHeaders' => array(AttributeType::Mixed),
           'awsStorageType' => array(AttributeType::String),
+          'removeMetadata' => array(AttributeType::Bool),
         );
     }
 

--- a/imager/services/ImagerService.php
+++ b/imager/services/ImagerService.php
@@ -263,6 +263,10 @@ class ImagerService extends BaseApplicationComponent
             } else {
                 $this->imageInstance->resize($resizeSize, $filterMethod);
             }
+
+            if ($this->imageDriver == 'imagick' && $this->getSetting('removeMetadata', $transform)) {
+                $this->imageInstance->strip($transform);
+            }
             
             if (!isset($transform['mode']) || mb_strtolower($transform['mode']) == 'crop' || mb_strtolower($transform['mode']) == 'croponly') {
                 $cropPoint = $this->_getCropPoint($resizeSize, $cropSize, $transform);

--- a/imager/services/ImagerService.php
+++ b/imager/services/ImagerService.php
@@ -264,6 +264,8 @@ class ImagerService extends BaseApplicationComponent
                 $this->imageInstance->resize($resizeSize, $filterMethod);
             }
 
+            // If Image Driver is imagick and removeMetadata is true
+            // remove Metadata to reduce the image size by a significant amount
             if ($this->imageDriver == 'imagick' && $this->getSetting('removeMetadata', $transform)) {
                 $this->imageInstance->strip($transform);
             }


### PR DESCRIPTION
I added the possibility to remove the image metadata if the selected image driver is imagick.
This option reduces the image size by a significant amount and it is also used by the craft core image transform function. 