### PR TITLE
Switched Imager_ImagePathsModel::__construct() to instanceof for Craft\AssetFileModel checks

### DIFF
--- a/imager/models/Imager_ImagePathsModel.php
+++ b/imager/models/Imager_ImagePathsModel.php
@@ -45,7 +45,7 @@ class Imager_ImagePathsModel extends BaseModel
             if (get_class($image) == 'Craft\Imager_ImageModel') {
                 $this->getPathsForLocalImagerFile($image->url);
             } else {
-                if (get_class($image) == 'Craft\AssetFileModel') {
+                if ($image instanceof \Craft\AssetFileModel) {
                     if (!$image->getSource()->getSourceType()->isSourceLocal()) { // it's a cloud source, pretend this is an external file for performance
                         $this->isRemote = true;
                         $this->_getPathsForUrl($image->getUrl());


### PR DESCRIPTION
Switched Imager_ImagePathsModel::__construct()'s use of get_class() to instanceof when checking for \Craft\AssetFileModel.