### PR TITLE
Added a `getDataUri` method to the `Imager_ImageModel`.

### DIFF
--- a/imager/models/Imager_ImageModel.php
+++ b/imager/models/Imager_ImageModel.php
@@ -90,7 +90,7 @@ class Imager_ImageModel extends BaseModel
     function getSize($unit = 'b', $precision = 2)
     {
         $unit = strtolower($unit);
-        
+
         switch ($unit) {
             case "g":
             case "gb":
@@ -107,8 +107,14 @@ class Imager_ImageModel extends BaseModel
             default:
                 return $this->size;
         }
-        
+
         return $this->height;
+    }
+
+    function getDataUri()
+    {
+        $image = IOHelper::getFileContents($this->path);
+        return 'data:image/' . $this->extension . ';base64,' . base64_encode($image);
     }
 
 }


### PR DESCRIPTION
This allows you to get the base64 encoded data uri of a given Imager image.

We needed this for our own projects as we want to inline the data uri of a tiny version of the image first to allow for a blurry preview on page load with the final image lazy loaded after.

We took inspiration from [this post](https://manu.ninja/dominant-colors-for-lazy-loading-images#tiny-thumbnails) and wanted the final effect to be something like this:

![Tiny thumbnail example](https://manu.ninja/images/tiny-thumbnails.jpg)

In the end the only thing I had to add was the `{{ imagerModel->dataUri }}` method as I can already resize the image down and make it a gif to get the smallest possible end result:

```twig
{% set images = entry.imageField.find() %}

{% set transform = {
	width : 212,
	height : 180
} %}

{% set preview = {
	format : 'gif',
	width : 3,
	height : 3,
} %}

{% for image in images %}
	{% set preview = craft.imager.transformImage(image, preview) %}
	<span style="display:inline-block;background-size:100%;background-repeat:no-repeat;background-image:url({{ preview.dataUri }});width:212px;height:180px;">
		<img src="{{ craft.imager.transformImage(image, transform) }}"  width="212" height="180" />
	</span>
{% endfor %}
```
