### PR TITLE
Make Imager compatible with the Craft FocusPoint plugin/fieldtype

### DIFF
--- a/imager/models/Imager_ImagePathsModel.php
+++ b/imager/models/Imager_ImagePathsModel.php
@@ -45,7 +45,7 @@ class Imager_ImagePathsModel extends BaseModel
             if (get_class($image) == 'Craft\Imager_ImageModel') {
                 $this->getPathsForLocalImagerFile($image->url);
             } else {
-                if (get_class($image) == 'Craft\AssetFileModel') {
+                if (get_class($image) == 'Craft\AssetFileModel' || get_class($image) == 'Craft\FocusPoint_AssetFileModel') {
                     if (!$image->getSource()->getSourceType()->isSourceLocal()) { // it's a cloud source, pretend this is an external file for performance
                         $this->isRemote = true;
                         $this->_getPathsForUrl($image->getUrl());


### PR DESCRIPTION
Imager was bombing out because it didn't recognise the FieldType for the (rather awesome) Craft-FocusPoint fieldtype... https://github.com/smcyr/Craft-FocusPoint