### PR TITLE
Fixing bug when determining remote images

### DIFF
--- a/imager/models/Imager_ImagePathsModel.php
+++ b/imager/models/Imager_ImagePathsModel.php
@@ -28,7 +28,7 @@ class Imager_ImagePathsModel extends BaseModel
             if (strpos($image, craft()->imager->getSetting('imagerUrl')) !== false) { // url to a file that is in the imager library
                 $this->getPathsForLocalImagerFile($image);
             } else {
-                if (strrpos($image, 'http') === 0 || strrpos($image, 'https') === 0 || strrpos($image, '//') === 0) { // external file
+                if (strpos($image, 'http') === 0 || strpos($image, 'https') === 0 || strpos($image, '//') === 0) { // external file
                     $this->isRemote = true;
                     if (strrpos($image, '//') === 0) {
                         $image = 'https:' . $image;


### PR DESCRIPTION
Changing use of `strrpos` for `strpos` because `strrpos` will give a false positive on an image sources with "http" in them eg. `strrpos("http://example.com/myhttpimage.jpg", "http") == 21`