### PR TITLE
Check for local assets path containing a URL now also checks for a relative URL.

### DIFF
--- a/imager/models/Imager_ImagePathsModel.php
+++ b/imager/models/Imager_ImagePathsModel.php
@@ -84,7 +84,7 @@ class Imager_ImagePathsModel extends BaseModel
     {
         $assetSourcePath = craft()->config->parseEnvironmentString($image->getSource()->settings['url']);
 
-        if (strncmp($assetSourcePath, 'http', 4) === 0) {
+        if (strncmp($assetSourcePath, 'http', 4) === 0 || strncmp($assetSourcePath, '//', 2) === 0) {
             $parsedUrl = parse_url($assetSourcePath);
             $assetSourcePath = $parsedUrl['path'];
         }


### PR DESCRIPTION
I'm in the habit of using a relative URL (beginning with a "//") for my baseURL definition, as I often need my assets to be protocol independent (due to different environments working on a mix of HTTP and HTTPS). The check for local asset paths does not expect these are therefore is not truncated down to the path folder in these cases, resulting in undesirable file paths. This pull request should fix this issue by also checking for a `$assetSourcePath` that begins with a "//", in addition to the check for those beginning with "http".