### PR TITLE
Windows Path Fix

### DIFF
--- a/imager/models/Imager_ImagePathsModel.php
+++ b/imager/models/Imager_ImagePathsModel.php
@@ -175,7 +175,8 @@ class Imager_ImagePathsModel extends BaseModel
             $parsedDirname = str_replace('.', '_', $urlParts['host']) . $targetFolder;
         }
 
-        $this->sourcePath = craft()->path->getRuntimePath() . 'imager/' . $parsedDirname . '/';
+        $runtimePath = IOHelper::getRealPath(craft()->path->getRuntimePath());
+        $this->sourcePath = $runtimePath . 'imager/' . $parsedDirname . '/';
         $this->sourceUrl = $image;
         $this->targetPath = craft()->imager->getSetting('imagerSystemPath') . $parsedDirname . '/';
         $this->targetUrl = craft()->imager->getSetting('imagerUrl') . $parsedDirname . '/';


### PR DESCRIPTION
Fixes an issue where Imager sometimes fails on windows because file paths look like `../craft/storage/runtime/imager/s3-us-west-2_amazonaws_com/some-bucket/siteMedia/Masthead-Backgrounds/` instead of `C:/dev/www/site/craft/storage/runtime/imager/s3-us-west-2_amazonaws_com/some-bucket/siteMedia/Masthead-Backgrounds/`.

Note: This is just me pushing code that fixed an issue that I spent a few hours troubleshooting. I didn't update the Imager version numbers or anything.