### PR TITLE
Fix asset source path for craft instances in sub directories

### DIFF
--- a/imager/models/Imager_ImagePathsModel.php
+++ b/imager/models/Imager_ImagePathsModel.php
@@ -87,6 +87,7 @@ class Imager_ImagePathsModel extends BaseModel
         if (strncmp($assetSourcePath, 'http', 4) === 0 || strncmp($assetSourcePath, '//', 2) === 0) {
             $parsedUrl = parse_url($assetSourcePath);
             $assetSourcePath = $parsedUrl['path'];
+            $assetSourcePath = str_replace(craft()->baseUrl, '', $assetSourcePath);
         }
 
         $hashPath = craft()->imager->getSetting('hashPath');


### PR DESCRIPTION
If craft runs in a subdirectory imager creates this subdirectory also as a folder.
The consequence is that on different environments this could lead to multiple transformed folders.

`http://localhost/craftWebsite`
this will create: `public/imager/craftWebsite/img...`

`http://localhost/otherEnv`
-> `public/imager/otherEnv/img...`

This is an issue for deployments of assets. So this part will be removed and imager should create the files relatively to the assets path.