### PR TITLE
Add an option to convert files to RGB

### DIFF
--- a/imager/config.php
+++ b/imager/config.php
@@ -45,6 +45,7 @@ return array(
   'instanceReuseEnabled' => false,
   'noop' => false,
   'suppressExceptions' => false,
+  'convertToRGB' => true, // Should images be converted to RGB?
     
   'fillTransforms' => false,
   'fillAttribute' => 'width', // this could be any attribute that is numeric

--- a/imager/models/Imager_ConfigModel.php
+++ b/imager/models/Imager_ConfigModel.php
@@ -66,6 +66,7 @@ class Imager_ConfigModel extends BaseModel
           'instanceReuseEnabled' => array(AttributeType::Bool),
           'noop' => array(AttributeType::Bool),
           'suppressExceptions' => array(AttributeType::Bool),
+          'convertToRGB' => array(AttributeType::Bool),
           'fillTransforms' => array(AttributeType::Bool),
           'fillAttribute' => array(AttributeType::String),
           'fillInterval' => array(AttributeType::Number),

--- a/imager/services/ImagerService.php
+++ b/imager/services/ImagerService.php
@@ -452,6 +452,10 @@ class ImagerService extends BaseApplicationComponent
                       array('imageDriver' => $this->imageDriver == 'gd' ? 'GD' : 'Imagick')));
                 }
             } else {
+                if ($this->getSetting('convertToRGB')) {
+                    $this->imageInstance->usePalette(new \Imagine\Image\Palette\RGB());
+                }
+
                 $this->imageInstance->save($targetFilePath, $saveOptions);
             }
 
@@ -1195,6 +1199,9 @@ class ImagerService extends BaseApplicationComponent
           'flatten' => true
         );
 
+        if ($this->getSetting('convertToRGB')) {
+            $imageInstance->usePalette(new \Imagine\Image\Palette\RGB());
+        }
         $imageInstance->save($targetFilePath, $saveOptions);
 
         return $targetFilePath;

--- a/imager/services/ImagerService.php
+++ b/imager/services/ImagerService.php
@@ -443,6 +443,11 @@ class ImagerService extends BaseApplicationComponent
                 $this->imageInstance->strip();
             }
 
+            // Convert the image to RGB before converting to webp/saving
+            if ($this->getSetting('convertToRGB', $transform)) {
+                $this->imageInstance->usePalette(new \Imagine\Image\Palette\RGB());
+            }
+
             // save the transform
             if ($targetExtension === 'webp') {
                 if ($this->hasSupportForWebP()) {
@@ -452,10 +457,6 @@ class ImagerService extends BaseApplicationComponent
                       array('imageDriver' => $this->imageDriver == 'gd' ? 'GD' : 'Imagick')));
                 }
             } else {
-                if ($this->getSetting('convertToRGB')) {
-                    $this->imageInstance->usePalette(new \Imagine\Image\Palette\RGB());
-                }
-
                 $this->imageInstance->save($targetFilePath, $saveOptions);
             }
 
@@ -1199,9 +1200,6 @@ class ImagerService extends BaseApplicationComponent
           'flatten' => true
         );
 
-        if ($this->getSetting('convertToRGB')) {
-            $imageInstance->usePalette(new \Imagine\Image\Palette\RGB());
-        }
         $imageInstance->save($targetFilePath, $saveOptions);
 
         return $targetFilePath;


### PR DESCRIPTION
cwebp seems to lack support for CMYK images, and regardless of that you might want to serve your images as RGB.

I added an option for it instead of forcing the conversion, in case anyone actually wants to display CMYK (or other palettes).

```
$ cwebp -af source.jpg
Unsupported color conversion request
Error! Could not process file source.jpg
Error! Cannot read input picture file 'source.jpg'
```

The source picture has the following format:
```
$ identify source.jpg
source.jpg JPEG 1920x823 1920x823+0+0 8-bit CMYK 4.547MB 0.120u 0:00.129
```

After converting it to RGB it successfully transforms.
