### PR TITLE
Add option for fallback image

### DIFF
--- a/imager/models/Imager_ConfigModel.php
+++ b/imager/models/Imager_ConfigModel.php
@@ -125,6 +125,9 @@ class Imager_ConfigModel extends BaseModel
           'curlOptions' => array(AttributeType::Mixed),
           'runTasksImmediatelyOnAjaxRequests' => array(AttributeType::Bool),
           'clearKey' => array(AttributeType::String),
+          'useFallBackImage' => array(AttributeType::Bool),
+          'fallBackImagePath' => array(AttributeType::String)
+
         );
     }
 

--- a/imager/services/ImagerService.php
+++ b/imager/services/ImagerService.php
@@ -261,6 +261,13 @@ class ImagerService extends BaseApplicationComponent
         
         // get pathsmodel for image
         $pathsModel = new Imager_ImagePathsModel($image);
+        
+        // use a fallback image if the file does not exist
+
+        if (!IOHelper::fileExists($pathsModel->sourcePath . $pathsModel->sourceFilename) && craft()->imager->getSetting('useFallBackImage')===true) {
+          $fallBackImagePath = craft()->imager->getSetting('fallBackImagePath') ? craft()->imager->getSetting('fallBackImagePath') : "https://dummyimage.com/600x400/000/fff";
+          $pathsModel = new Imager_ImagePathsModel($fallBackImagePath);
+        }
 
         // create imagine instance
         $this->imagineInstance = $this->_createImagineInstance();


### PR DESCRIPTION
Hi 

Would you consider adding this to the project? This is for situations where the database "thinks" there is an image, but the image is not physically on the hard drive. This happens during development quite a bit as we don't want to pull down all images associated with the project.

Thanks,
Richard