### PR TITLE
Fix incorrect Content-Length header when uploading to S3

### DIFF
--- a/imager/services/Imager_AwsService.php
+++ b/imager/services/Imager_AwsService.php
@@ -33,6 +33,9 @@ class Imager_AwsService extends BaseApplicationComponent
     {
         $s3 = $this->_getS3Object();
 
+        // clear stat cache so that filesize() reports correct size after optimizations are applied
+        clearstatcache(true, $filePath);
+
         $file = $s3->inputFile($filePath);
         $headers = craft()->imager->getSetting('awsRequestHeaders');
 


### PR DESCRIPTION
Was having same issue as #87.

After some research (for example https://github.com/aws/aws-sdk-js/issues/281), I found that this Request Timeout could be related to an incorrect Content-Length header.

I found that if you were applying image optimizations like pngQuant, that the `filesize` call used by the S3 client was getting an incorrect size that was cached--the size of the file prior to the optimization.

This PR resets that cached file size prior to uploading to S3.