### PR TITLE
Adds Yii alias support to imagerSystemPath setting

### DIFF
--- a/src/models/LocalSourceImageModel.php
+++ b/src/models/LocalSourceImageModel.php
@@ -23,6 +23,7 @@ use aelvan\imager\helpers\ImagerHelpers;
 use aelvan\imager\services\ImagerService;
 use aelvan\imager\exceptions\ImagerException;
 
+use Yii;
 use yii\base\Exception;
 use yii\base\InvalidConfigException;
 
@@ -259,7 +260,7 @@ class LocalSourceImageModel
         $this->transformPath = ImagerHelpers::getTransformPathForPath($image);
         $pathParts = pathinfo($image);
 
-        $this->path = FileHelper::normalizePath($_SERVER['DOCUMENT_ROOT'].'/'.$pathParts['dirname']);
+        $this->path = FileHelper::normalizePath(Yii::getAlias('@webroot').'/'.$pathParts['dirname']);
         $this->url = $image;
         $this->filename = $pathParts['basename'];
         $this->basename = $pathParts['filename'];

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -3,11 +3,12 @@
 namespace aelvan\imager\models;
 
 use craft\base\Model;
+use Yii;
 
 class Settings extends Model
 {
     public $transformer = 'craft';
-    public $imagerSystemPath = '/imager/';
+    public $imagerSystemPath = '@webroot/imager/';
     public $imagerUrl = '/imager/';
     public $cacheEnabled = true;
     public $cacheRemoteFiles = true;
@@ -159,8 +160,8 @@ class Settings extends Model
 
     public function init()
     {
-        // Have to set this here cause $_SERVER['DOCUMENT_ROOT'] can't be used in default value
-        $this->imagerSystemPath = $_SERVER['DOCUMENT_ROOT'].'/imager/';
+        // Have to set this here cause Yii::getAlias can't be used in default value
+        $this->imagerSystemPath = Yii::getAlias($this->imagerSystemPath);
         $this->suppressExceptions = !\Craft::$app->getConfig()->general->devMode;
     }
 }


### PR DESCRIPTION
The `$_SERVER['DOCUMENT_ROOT']` variable isn't always set (hello, Valet!), so in my opinion, it makes sense to use Craft's `@webroot` alias instead. And, by piping `imagerSystemPath` through `Yii::getAlias()`, the setting will now support any registered path alias.

* Adds Yii alias support to the `imagerSystemPath` setting.
* Sets the default `imagerSystemPath` setting to `'@webroot/imager'`
* Replaces `$_SERVER['DOCUMENT_ROOT']` with `Yii::getAlias('@webroot')`