### PR TITLE
Fix issue with invalid remote filenames

### DIFF
--- a/src/models/LocalSourceImageModel.php
+++ b/src/models/LocalSourceImageModel.php
@@ -126,7 +126,9 @@ class LocalSourceImageModel
      */
     public function getFilePath(): string
     {
-        return FileHelper::normalizePath($this->path.'/'.$this->filename);
+        $filename = FileHelper::sanitizeFilename($this->filename);
+
+        return FileHelper::normalizePath($this->path.'/'.$filename);
     }
 
     /**

--- a/src/models/LocalSourceImageModel.php
+++ b/src/models/LocalSourceImageModel.php
@@ -126,9 +126,7 @@ class LocalSourceImageModel
      */
     public function getFilePath(): string
     {
-        $filename = FileHelper::sanitizeFilename($this->filename);
-
-        return FileHelper::normalizePath($this->path.'/'.$filename);
+        return FileHelper::normalizePath($this->path.'/'.$this->filename);
     }
 
     /**
@@ -293,7 +291,7 @@ class LocalSourceImageModel
         $this->url = $image;
         $this->basename = str_replace(' ', '-', $pathParts['filename']).($queryString !== '' ? '_'.md5($queryString) : '');
         $this->extension = $pathParts['extension'] ?? '';
-        $this->filename = $this->basename.'.'.$this->extension;
+        $this->filename = FileHelper::sanitizeFilename($this->basename.'.'.$this->extension);
 
         try {
             FileHelper::createDirectory($this->path);


### PR DESCRIPTION
I came across an issue where if the remote filename contained invalid characters (asterisk in my case) the local filename of the local file that you would download the remote file into would be invalid and you would get an error telling you the file does not exist.