### PR TITLE
Replace time() with microtime() for temporary file name

### DIFF
--- a/src/transformers/CraftTransformer.php
+++ b/src/transformers/CraftTransformer.php
@@ -543,7 +543,7 @@ class CraftTransformer extends Component implements TransformerInterface
             }
         }
 
-        $targetFilePath = $tempPath.md5(time()).'.'.$sourceExtension;
+        $targetFilePath = $tempPath.md5(microtime()).'.'.$sourceExtension;
 
         $saveOptions = [
             'jpeg_quality' => 100,


### PR DESCRIPTION
Stops collisions when processing lots of image transforms quickly.

md5(time()) isn't unique when processing lots of image manipulations quickly and results in errors when using cwebp:

"Temporary file save operation failed: "
"unlink(/Users/joe/Sites/example-site/storage/runtimeimager/temp/52b483018ee804f1eac2e29d1b464cf5.jpg): No such file or directory"