### PR TITLE
Adds support for purging images from Imgix

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ A valid Imgix API key is required to enable the [Imgix purging](https://docs.img
 
 ### imgixEnableAutoPurging [bool]
 *Default: `true`*  
-Attempts to [purge](https://docs.imgix.com/setup/purging-images) images automatically when the Asset is replaced, or edited with the Image Editor (i.e. cropped, resized etc). 
+Attempts to [purge](https://docs.imgix.com/setup/purging-images) images automatically when the Asset is replaced, or edited with the Image Editor (i.e. cropped, resized etc). _An Imgix API key is required to enable purging._  
 
 ### imgixEnablePurgeElementAction [bool]
 *Default: `true`*  

--- a/README.md
+++ b/README.md
@@ -370,13 +370,25 @@ Overrides Craft's internal thumb transform in the control panel with Imager's. M
 *Default: `'default'`*  
 Imgix config settings profile to be used. Must correspond to a key in `imgixConfig`.
 
+### imgixApiKey [string]
+*Default: `''`*
+A valid Imgix API key is required to enable the [Imgix purging](https://docs.imgix.com/setup/purging-images) features. Note that in addition to setting the `imgixApiKey` setting, you can also add per-profile API keys for specific sources inside the `imgixConfig` configuration object – useful if you're using sources belonging to different Imgix accounts.
+
+### imgixEnableAutoPurging [bool]
+*Default: `true`*
+Attempts to [purge](https://docs.imgix.com/setup/purging-images) images automatically when assets are replaced or edited with the Image Editor.
+
+### imgixEnablePurgeElementAction [bool]
+*Default: `true`*
+Adds a "Purge from Imgix" element action to the Asset index. Note that if purging is not possible (i.e. if there's no Imgix API key set or there are no purgable profiles in the `imgixConfig` array) the element action will not display, regardless of this setting.
+
 ### imgixConfig [array]  
 An array of configuration objects for Imgix, where the key is the profile handle. The configuration object takes the following settings:
 
 **domains (array):** An array of Imgix source domains.  
 **useHttps (bool):** Indicates if generated Imgix URLs should be https or not.  
 **signKey (string):** If you've protected your source with secure URLs, you must provide the sign key/token. An empty string indicates that the source is not secure.  
-**sourceIsWebProxy (bool):** Indicates if your Imgix source is a web proxy or not.   
+**sourceIsWebProxy (bool):** Indicates if your Imgix source is a web proxy or not. Note that web proxy sources will be excluded from purging.
 **useCloudSourcePath (bool):** If enabled, Imager will prepend the Craft source path to the asset path, before passing it to the Imgix URL builder. This makes it possible to have one Imgix source pulling images from many Craft volumes when they are on the same S3 bucket, but in different subfolder. This only works on volumes that implements a path setting (AWS S3 and GCS does, local volumes does not).  
 **shardStrategy (string):** etermines the sharding strategy if more than one source is used. Allowed values are `cycle` and `crc`.  
 **getExternalImageDimensions (bool):** Imager does its best at determining the dimensions of the transformed images. If the supplied asset is on Craft source, it's easy because Craft records the original dimensions of the image in the database. But if the image is external, it's not that easy. Imager will try to determine the size based on the transform parameters, and if both width and height, or ratio is provided, it'll usually be able to. But if you only transform by one attribute, it may not be possible. In these cases Imager will by default download the source image and check the dimensions to calculate the missing bits.
@@ -415,6 +427,9 @@ The following example shows a setup that uses two Imgix sources, one that's poin
 To use specify which profile to use in your templates you override `imgixProfile` like this:
 
     {% set transform = craft.imager.transformImage(externalUrl, { width: 400 }, {}, { imgixProfile: 'external' }) %}
+
+**excludeFromPurge (bool):** Exclude this source from purging. Note that profiles with the `sourceIsWebProxy` setting set to `true` will be excluded from purging regardless of this value.
+**apiKey (string):** Will override the `imgixApiKey` setting when Imager attempts to purge images for a particular profile. Useful if you use sources belonging to different Imgix accounts.
 
 ### optimizeType [string]
 *Default: `'job'`*  

--- a/README.md
+++ b/README.md
@@ -376,11 +376,11 @@ A valid Imgix API key is required to enable the [Imgix purging](https://docs.img
 
 ### imgixEnableAutoPurging [bool]
 *Default: `true`*  
-Attempts to [purge](https://docs.imgix.com/setup/purging-images) images automatically when assets are replaced or edited with the Image Editor.
+Attempts to [purge](https://docs.imgix.com/setup/purging-images) images automatically when the Asset is replaced, or edited with the Image Editor (i.e. cropped, resized etc). 
 
 ### imgixEnablePurgeElementAction [bool]
 *Default: `true`*  
-Adds a "Purge from Imgix" element action to the Asset index. Note that if purging is not possible (i.e. if there's no Imgix API key set or there are no purgable profiles in the `imgixConfig` array) the element action will not display, regardless of this setting.
+Adds a "Purge from Imgix" element action to the Asset index, for manually triggering purge. Note that if purging is not possible (i.e. if there's no Imgix API key set or there are no purgable profiles in the `imgixConfig` array) the element action will not display, regardless of this setting.  
 
 ### imgixConfig [array]  
 An array of configuration objects for Imgix, where the key is the profile handle. The configuration object takes the following settings:
@@ -428,7 +428,7 @@ To use specify which profile to use in your templates you override `imgixProfile
 
     {% set transform = craft.imager.transformImage(externalUrl, { width: 400 }, {}, { imgixProfile: 'external' }) %}
 
-**excludeFromPurge (bool):** Exclude this source from purging. Note that profiles with the `sourceIsWebProxy` setting set to `true` will be excluded from purging regardless of this value.  
+**excludeFromPurge (bool):** Exclude this source from purging. Note that profiles with the `sourceIsWebProxy` setting set to `true` will be excluded from purging regardless of this value. _This setting affects both automatic purging when Assets are replaced (or edited with the Image Editor) and manual purges triggered by the element action._  
 **apiKey (string):** Will override the `imgixApiKey` setting when Imager attempts to purge images for a particular profile. Useful if you use sources belonging to different Imgix accounts.  
 
 ### optimizeType [string]

--- a/README.md
+++ b/README.md
@@ -386,11 +386,17 @@ Adds a "Purge from Imgix" element action to the Asset index, for manually trigge
 An array of configuration objects for Imgix, where the key is the profile handle. The configuration object takes the following settings:
 
 **domains (array):** An array of Imgix source domains.  
+
 **useHttps (bool):** Indicates if generated Imgix URLs should be https or not.  
+
 **signKey (string):** If you've protected your source with secure URLs, you must provide the sign key/token. An empty string indicates that the source is not secure.  
-**sourceIsWebProxy (bool):** Indicates if your Imgix source is a web proxy or not. Note that web proxy sources will be excluded from purging.
+
+**sourceIsWebProxy (bool):** Indicates if your Imgix source is a web proxy or not. Note that web proxy sources will be excluded from purging.  
+
 **useCloudSourcePath (bool):** If enabled, Imager will prepend the Craft source path to the asset path, before passing it to the Imgix URL builder. This makes it possible to have one Imgix source pulling images from many Craft volumes when they are on the same S3 bucket, but in different subfolder. This only works on volumes that implements a path setting (AWS S3 and GCS does, local volumes does not).  
+
 **shardStrategy (string):** etermines the sharding strategy if more than one source is used. Allowed values are `cycle` and `crc`.  
+
 **getExternalImageDimensions (bool):** Imager does its best at determining the dimensions of the transformed images. If the supplied asset is on Craft source, it's easy because Craft records the original dimensions of the image in the database. But if the image is external, it's not that easy. Imager will try to determine the size based on the transform parameters, and if both width and height, or ratio is provided, it'll usually be able to. But if you only transform by one attribute, it may not be possible. In these cases Imager will by default download the source image and check the dimensions to calculate the missing bits.
 
 By disabling this setting, you're telling Imager to never download external images, and to just give up on trying to figure out the dimensions. If you supplied only width to the transform, height will then be set to 0. If you don't need to use height in your code, that's totally fine, and you've managed to squeeze out a bit more performance.
@@ -429,6 +435,7 @@ To use specify which profile to use in your templates you override `imgixProfile
     {% set transform = craft.imager.transformImage(externalUrl, { width: 400 }, {}, { imgixProfile: 'external' }) %}
 
 **excludeFromPurge (bool):** Exclude this source from purging. Note that profiles with the `sourceIsWebProxy` setting set to `true` will be excluded from purging regardless of this value. _This setting affects both automatic purging when Assets are replaced (or edited with the Image Editor) and manual purges triggered by the element action._  
+
 **apiKey (string):** Will override the `imgixApiKey` setting when Imager attempts to purge images for a particular profile. Useful if you use sources belonging to different Imgix accounts.  
 
 ### optimizeType [string]

--- a/README.md
+++ b/README.md
@@ -371,15 +371,15 @@ Overrides Craft's internal thumb transform in the control panel with Imager's. M
 Imgix config settings profile to be used. Must correspond to a key in `imgixConfig`.
 
 ### imgixApiKey [string]
-*Default: `''`*
+*Default: `''`*  
 A valid Imgix API key is required to enable the [Imgix purging](https://docs.imgix.com/setup/purging-images) features. Note that in addition to setting the `imgixApiKey` setting, you can also add per-profile API keys for specific sources inside the `imgixConfig` configuration object – useful if you're using sources belonging to different Imgix accounts.
 
 ### imgixEnableAutoPurging [bool]
-*Default: `true`*
+*Default: `true`*  
 Attempts to [purge](https://docs.imgix.com/setup/purging-images) images automatically when assets are replaced or edited with the Image Editor.
 
 ### imgixEnablePurgeElementAction [bool]
-*Default: `true`*
+*Default: `true`*  
 Adds a "Purge from Imgix" element action to the Asset index. Note that if purging is not possible (i.e. if there's no Imgix API key set or there are no purgable profiles in the `imgixConfig` array) the element action will not display, regardless of this setting.
 
 ### imgixConfig [array]  
@@ -428,8 +428,8 @@ To use specify which profile to use in your templates you override `imgixProfile
 
     {% set transform = craft.imager.transformImage(externalUrl, { width: 400 }, {}, { imgixProfile: 'external' }) %}
 
-**excludeFromPurge (bool):** Exclude this source from purging. Note that profiles with the `sourceIsWebProxy` setting set to `true` will be excluded from purging regardless of this value.
-**apiKey (string):** Will override the `imgixApiKey` setting when Imager attempts to purge images for a particular profile. Useful if you use sources belonging to different Imgix accounts.
+**excludeFromPurge (bool):** Exclude this source from purging. Note that profiles with the `sourceIsWebProxy` setting set to `true` will be excluded from purging regardless of this value.  
+**apiKey (string):** Will override the `imgixApiKey` setting when Imager attempts to purge images for a particular profile. Useful if you use sources belonging to different Imgix accounts.  
 
 ### optimizeType [string]
 *Default: `'job'`*  

--- a/src/elementactions/ImgixPurgeElementAction.php
+++ b/src/elementactions/ImgixPurgeElementAction.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Imager plugin for Craft CMS 3.x
+ *
+ * Image transforms gone wild
+ *
+ * @link      https://www.vaersaagod.no
+ * @copyright Copyright (c) 2018 André Elvan
+ */
+
+namespace aelvan\imager\elementactions;
+
+use aelvan\imager\Imager;
+
+use Craft;
+use craft\elements\db\ElementQueryInterface;
+use craft\base\ElementAction;
+
+use aelvan\imager\Imager as Plugin;
+
+class ImgixPurgeElementAction extends ElementAction
+{
+
+    /**
+     * @inheritdoc
+     */
+    public function getTriggerLabel(): string
+    {
+        return Craft::t('imager', 'Purge from Imgix');
+    }
+
+    /**
+     * Purges selected image Assets from Imgix
+     *
+     * @param ElementQueryInterface $query
+     *
+     * @return bool
+     */
+    public function performAction(ElementQueryInterface $query): bool
+    {
+
+        $imagesToPurge = $query->kind('image')->all();
+
+        if (empty($imagesToPurge)) {
+            $this->setMessage(Craft::t('imager', 'No images to purge'));
+            return true;
+        }
+
+        /** @var Imager $imagerPlugin */
+        $imagerPlugin = Plugin::$plugin;
+
+        try {
+            foreach ($imagesToPurge as $imageToPurge) {
+                $imagerPlugin->imgix->purgeAssetFromImgix($imageToPurge);
+            }
+        } catch (\Throwable $e) {
+            $this->setMessage($e->getMessage());
+            return false;
+        }
+
+        $numImagesToPurge = \count($imagesToPurge);
+        if ($numImagesToPurge > 1) {
+            $this->setMessage(Craft::t('imager', 'Purging {count} images from Imgix...', [
+                'count' => $numImagesToPurge,
+            ]));
+            return true;
+        }
+
+        $this->setMessage(Craft::t('imager', 'Purging image from Imgix...'));
+        return true;
+    }
+}

--- a/src/models/ImgixSettings.php
+++ b/src/models/ImgixSettings.php
@@ -14,6 +14,8 @@ class ImgixSettings extends Model
     public $shardStrategy = 'cycle';
     public $getExternalImageDimensions = false;
     public $defaultParams = [];
+    public $excludeFromPurge = false;
+    public $apiKey = '';
     
     public function __construct($config = [])
     {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -55,6 +55,9 @@ class Settings extends Model
     public $useForCpThumbs = false;
 
     public $imgixProfile = 'default';
+    public $imgixApiKey = '';
+    public $imgixEnableAutoPurging = true;
+    public $imgixEnablePurgeElementAction = true;
     public $imgixConfig = [
         'default' => [
             'domains' => [],
@@ -65,6 +68,8 @@ class Settings extends Model
             'shardStrategy' => 'cycle',
             'getExternalImageDimensions' => true,
             'defaultParams' => [],
+            'apiKey' => '',
+            'excludeFromPurge' => false,
         ]
     ];
     

--- a/src/services/ImgixService.php
+++ b/src/services/ImgixService.php
@@ -19,6 +19,7 @@ use Imgix\UrlBuilder;
 use GuzzleHttp\RequestOptions;
 
 use Craft;
+use craft\base\Component;
 use craft\base\LocalVolumeInterface;
 use craft\base\Volume;
 use craft\elements\Asset;
@@ -35,7 +36,7 @@ use yii\base\InvalidConfigException;
  * @package   Imager
  * @since     2.1.2
  */
-class ImgixService
+class ImgixService extends Component
 {
 
     /**

--- a/src/services/ImgixService.php
+++ b/src/services/ImgixService.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Imager plugin for Craft CMS 3.x
+ *
+ * Image transforms gone wild
+ *
+ * @link      https://www.vaersaagod.no
+ * @copyright Copyright (c) 2017 André Elvan
+ */
+
+namespace aelvan\imager\services;
+
+use aelvan\imager\exceptions\ImagerException;
+use aelvan\imager\models\ConfigModel;
+use aelvan\imager\models\ImgixSettings;
+use aelvan\imager\services\ImagerService;
+
+use Imgix\UrlBuilder;
+use GuzzleHttp\RequestOptions;
+
+use Craft;
+use craft\base\LocalVolumeInterface;
+use craft\base\Volume;
+use craft\elements\Asset;
+use craft\volumes\Local;
+
+use yii\base\InvalidConfigException;
+
+/**
+ * ImgixService Service
+ *
+ * https://craftcms.com/docs/plugins/services
+ *
+ * @author    Mats Mikkel Rummelhoff
+ * @package   Imager
+ * @since     2.1.2
+ */
+class ImgixService
+{
+
+    /**
+     *  The Imgix API endpoint for purging images
+     */
+    const PURGE_ENDPOINT = 'https://api.imgix.com/v2/image/purger';
+
+    /**
+     * @var bool If purging is enabled or not
+     */
+    protected static $canPurge;
+
+    /**
+     * Purging is possible if there's an `imgixConfig` map, and all sources/profiles have an API key set
+     * Used for determining if the ImgixPurgeElementAction element action and various related event handlers should be bootstrapped or not
+     *
+     * @return bool
+     */
+    public static function getCanPurge(): bool
+    {
+        if (!isset(self::$canPurge)) {
+            /** @var ConfigModel $settings */
+            $config = ImagerService::getConfig();
+            // No Imgix config, no purging
+            $imgixConfigArr = $config->getSetting('imgixConfig');
+            if (!$imgixConfigArr || !\is_array($imgixConfigArr) || empty($imgixConfigArr)) {
+                self::$canPurge = false;
+                return false;
+            }
+            // Make sure there's at least one profile that is not a web proxy and that is not excluded from purging
+            $hasApiKey = !!$config->getSetting('imgixApiKey');
+            $hasPurgableProfile = false;
+            foreach ($imgixConfigArr as $profile => $imgixConfig) {
+                $imgixConfig = new ImgixSettings($imgixConfig);
+                $hasApiKey = $hasApiKey || !!$imgixConfig->apiKey;
+                $hasPurgableProfile = $hasPurgableProfile || (!$imgixConfig->sourceIsWebProxy && !$imgixConfig->excludeFromPurge);
+                if ($hasApiKey && $hasPurgableProfile) {
+                    break;
+                }
+            }
+            self::$canPurge = $hasApiKey && $hasPurgableProfile;
+        }
+        return self::$canPurge;
+    }
+
+    /**
+     * @param string $url The base URL to the image you wish to purge (e.g. https://your-imgix-source.imgix.net/image.jpg)
+     * @param string $apiKey Imgix API key
+     * @throws ImagerException
+     */
+    public function purgeUrlFromImgix(string $url, string $apiKey)
+    {
+        try {
+            $client = Craft::createGuzzleClient();
+            $client->post(self::PURGE_ENDPOINT, [
+                'headers' => [
+                    'Content-Type'  => 'application/json',
+                    'Authorization' => 'Basic ' . \base64_encode("{$apiKey}:")
+                ],
+                RequestOptions::JSON => [
+                    'url' => $url
+                ],
+            ]);
+
+        } catch (\Throwable $e) {
+            Craft::error($e->getMessage(), __METHOD__);
+            throw new ImagerException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * @param Asset $asset The Asset you wish to purge
+     * @throws ImagerException
+     */
+    public function purgeAssetFromImgix(Asset $asset)
+    {
+        /** @var ConfigModel $settings */
+        $config = ImagerService::getConfig();
+
+        $imgixApiKey = $config->getSetting('imgixApiKey');
+        $imgixConfigArr = $config->getSetting('imgixConfig');
+
+        if (!$imgixConfigArr || !\is_array($imgixConfigArr) || empty($imgixConfigArr)) {
+            $msg = Craft::t('imager', 'The "imgixConfig" config setting is missing, or is not correctly set up.');
+            Craft::error($msg, __METHOD__);
+            throw new ImagerException($msg);
+        }
+
+        foreach ($imgixConfigArr as $profile => $imgixConfig) {
+
+            $imgixConfig = new ImgixSettings($imgixConfig);
+            if ($imgixConfig->sourceIsWebProxy || $imgixConfig->excludeFromPurge) {
+                continue;
+            }
+
+            $apiKey = $imgixConfig->apiKey ?: $imgixApiKey;
+            if (!$apiKey) {
+                continue;
+            }
+
+            $domains = $imgixConfig->domains;
+
+            if (!\is_array($domains) || empty($domains)) {
+                $msg = Craft::t('imager', 'Imgix config setting “domains” does not appear to be correctly set up. It needs to be an array of strings representing your Imgix source\'s domains.');
+                Craft::error($msg, __METHOD__);
+                throw new ImagerException($msg);
+            }
+
+            // Loop over this profile's domains
+            foreach ($domains as $domain) {
+
+                try {
+
+                    /** @var LocalVolumeInterface|Volume|Local $volume */
+                    $volume = $asset->getVolume();
+
+                    // Get the image's path
+                    if (($imgixConfig->useCloudSourcePath === true) && isset($volume->subfolder) && \get_class($volume) !== 'craft\volumes\Local') {
+                        $path = implode('/', [$volume->subfolder, $asset->getPath()]);
+                    } else {
+                        $path = $asset->getPath();
+                    }
+
+                    // Build base URL for the image on Imgix
+                    $builder = new UrlBuilder([$domain], $imgixConfig->useHttps, null, null, false);
+                    $url = $builder->createURL(\str_replace('%2F', '/', \urlencode($path)));
+
+                    $this->purgeUrlFromImgix($url, $apiKey);
+
+                } catch (\Throwable $e) {
+                    Craft::error($e->getMessage(), __METHOD__);
+                    throw new ImagerException($e->getMessage(), $e->getCode(), $e);
+                }
+
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Adds in automatic image purging from Imgix whenever an Asset is replaced. Also adds element action for manually purging images from Imgix.

Note that the purging feature hinges on the new `imgixApiKey` config setting being set to a valid Imgix API key (purging is not possible without a valid key).