### PR TITLE
Don't send default quality with Imgix auto compression

### DIFF
--- a/src/transformers/ImgixTransformer.php
+++ b/src/transformers/ImgixTransformer.php
@@ -185,7 +185,13 @@ class ImgixTransformer extends Component implements TransformerInterface
         }
 
         // Set quality 
-        if (!isset($transform['q'])) {
+        if (
+            !isset($transform['q'])
+                && !(
+                    isset($transform['auto'])
+                    && strstr($transform['auto'], 'compress')
+                )
+            ) {
             if (isset($r['fm'])) {
                 $r['q'] = $this->getQualityFromExtension($r['fm'], $transform);
             } else {

--- a/src/transformers/ImgixTransformer.php
+++ b/src/transformers/ImgixTransformer.php
@@ -187,11 +187,8 @@ class ImgixTransformer extends Component implements TransformerInterface
         // Set quality 
         if (
             !isset($transform['q'])
-                && !(
-                    isset($transform['auto'])
-                    && strstr($transform['auto'], 'compress')
-                )
-            ) {
+            && !$this->transformHasAutoCompressionEnabled($transform)
+        ) {
             if (isset($r['fm'])) {
                 $r['q'] = $this->getQualityFromExtension($r['fm'], $transform);
             } else {
@@ -319,6 +316,20 @@ class ImgixTransformer extends Component implements TransformerInterface
         }
 
         return $r;
+    }
+
+    /**
+     * Check if transform has auto compression enabled
+     *
+     * @param array $transform
+     *
+     * @return bool
+     */
+    private function transformHasAutoCompressionEnabled(array $transform): bool
+    {
+        return
+            isset($transform['auto'])
+            && strstr($transform['auto'], 'compress');
     }
 
     /**


### PR DESCRIPTION
This PR changes the behaviour for the configuration `imgixConfig.default.defaultParams`.

**Current situation**

```
'defaultParams' => [
    'auto' => 'compress',
],
```

The `auto=compress` and `q=80` parameters are sent to Imgix. Even though we didn't set the `q` parameter. So it is currently impossible to only use `auto=compress`.

**Pull request**

```
'defaultParams' => [
    'auto' => 'compress',
],
```

Only the `auto=compress` parameter is sent to Imgix. You let Imgix decide on the quality `q`. According to the [Imgix docs](https://docs.imgix.com/apis/url/auto/auto#compress), the quality will be set to `45` if `auto=compress` is used.

```
'defaultParams' => [
    'auto' => 'compress',
    'q' => '80',
],
```

You can still set `q` if you want to make the decision yourself.

---

So basically. This PR makes it possible to let Imgix decide on the `q` quality parameter if you're using `auto=compress`.