### PR TITLE
Fixes in issue with running Imager transforms from the command line

### DIFF
--- a/src/transformers/CraftTransformer.php
+++ b/src/transformers/CraftTransformer.php
@@ -106,7 +106,7 @@ class CraftTransformer extends Component implements TransformerInterface
         }
 
         // If ajax request, trigger jobs immediately
-        if ($taskCreated && $config->runJobsImmediatelyOnAjaxRequests && Craft::$app->getRequest()->getIsAjax()) {
+        if (!Craft::$app->getRequest()->isConsoleRequest && $taskCreated && $config->runJobsImmediatelyOnAjaxRequests && Craft::$app->getRequest()->getIsAjax()) {
             $this->triggerQueueNow();
         }
 


### PR DESCRIPTION
I'm  trying to add [craft-imagerpretransform](https://github.com/superbigco/craft-imagerpretransform) to my site but when I run the command to generate transforms the following error is thrown:

```
Exception 'yii\base\UnknownMethodException' with message 'Calling unknown method: craft\console\Request::getIsAjax()'

in /vendor/yiisoft/yii2/base/Component.php:300

Stack trace:
#0 /vendor/aelvan/imager/src/transformers/CraftTransformer.php(109): yii\base\Component->__call('getIsAjax', Array)
#1 /vendor/aelvan/imager/src/services/ImagerService.php(337): aelvan\imager\transformers\CraftTransformer->transform(Object(craft\elements\Asset), Array)
#2 /vendor/superbig/craft-imagerpretransform/src/services/ImagerPretransformService.php(98): aelvan\imager\services\ImagerService->transformImage(Object(craft\elements\Asset), Array, NULL, NULL)
```

This PR should fix that.

Thanks for having a look!
