### PR TITLE
Files with upper case extensions are not transformed

### DIFF
--- a/src/Imager.php
+++ b/src/Imager.php
@@ -175,7 +175,7 @@ class Imager extends Plugin
             function(GetAssetUrlEvent $event) {
                 $config = ImagerService::getConfig();
                 
-                if ($config->useForNativeTransforms && $event->asset !== null && $event->transform !== null && $event->asset->kind === 'image' && \in_array($event->asset->getExtension(), Image::webSafeFormats(), true)) {
+                if ($config->useForNativeTransforms && $event->asset !== null && $event->transform !== null && $event->asset->kind === 'image' && \in_array(strtolower($event->asset->getExtension()), Image::webSafeFormats(), true)) {
                     try {
                         $transformedImage = self::$plugin->imager->transformImage($event->asset, $event->transform);
                         if ($transformedImage !== null) {


### PR DESCRIPTION
Falls back to craft transforms when files have an uppercase extension when useForNativeTransforms: true. 

Prob no big deal, unless IMGIX is used, where we're trying to avoid using craft transforms. 