### PR TITLE
Fix AWS paths on Windows

### DIFF
--- a/src/externalstorage/AwsStorage.php
+++ b/src/externalstorage/AwsStorage.php
@@ -49,6 +49,9 @@ class AwsStorage implements ImagerStorageInterface
             $uri = ltrim(FileHelper::normalizePath($settings['folder'].'/'.$uri), '/');
         }
 
+        //always use forward slashes for S3
+        $uri = str_replace('\\', '/', $uri);
+
         $opts = $settings['requestHeaders'];
         $cacheDuration = $isFinal ? $config->cacheDurationExternalStorage : $config->cacheDurationNonOptimized;
 


### PR DESCRIPTION
Imager is correctly using forward slashes for Windows, but isn't changing them to back slashes when uploading to S3. This causes the image filenames to include their entire file path as opposed to creating their folder hierarchies as expected.