### PR TITLE
Fix for imgix URLs on Windows

### DIFF
--- a/src/helpers/ImgixHelpers.php
+++ b/src/helpers/ImgixHelpers.php
@@ -58,7 +58,10 @@ class ImgixHelpers
         }
         
         $path = FileHelper::normalizePath($path);
-        
+
+        //always use forward slashes for imgix
+        $path = str_replace('\\', '/', $path);
+
         return self::getUrlEncodedPath($path);
     }
     


### PR DESCRIPTION
Imager is correctly using forward slashes for Windows, but isn't changing them to back slashes when outputting the imgix URLs. This causes the generated URL to have encoded back slashes and results in a 404 always being thrown.