### PR TITLE
Simplify AWS storage configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Imager Changelog
 
+## unreleased
+### Changed
+- AWS credentials can now be configured via IAM role, shared credentials file, or environment variables, when `accessKey` and `secretAccessKey` are left blank in the storage config settings.
+- The `requestHeaders` and `storageType` storage config settings for AWS are now optional.
+
 ## 2.1.10 - 2019-04-13
 ### Fixed
 - Fixed issues with using named transforms or `AssetTransform` models when `useForNativeTransforms` is `true` (fixes #237).

--- a/src/externalstorage/AwsStorage.php
+++ b/src/externalstorage/AwsStorage.php
@@ -52,7 +52,7 @@ class AwsStorage implements ImagerStorageInterface
         //always use forward slashes for S3
         $uri = str_replace('\\', '/', $uri);
 
-        $opts = $settings['requestHeaders'];
+        $opts = $settings['requestHeaders'] ?? [];
         $cacheDuration = $isFinal ? $config->cacheDurationExternalStorage : $config->cacheDurationNonOptimized;
 
         if (!isset($opts['Cache-Control'])) {
@@ -64,7 +64,7 @@ class AwsStorage implements ImagerStorageInterface
             'Key' => $uri,
             'Body' => fopen($file, 'rb'),
             'ACL' => 'public-read',
-            'StorageClass' => self::getAWSStorageClass($settings['storageType']),
+            'StorageClass' => self::getAWSStorageClass($settings['storageType'] ?? 'standard'),
         ]);
 
         try {

--- a/src/externalstorage/AwsStorage.php
+++ b/src/externalstorage/AwsStorage.php
@@ -32,11 +32,14 @@ class AwsStorage implements ImagerStorageInterface
         $clientConfig = [
             'version' => 'latest',
             'region' => $settings['region'],
-            'credentials' => [
+        ];
+
+        if (isset($settings['accessKey'], $settings['secretAccessKey'])) {
+            $clientConfig['credentials'] = [
                 'key' => $settings['accessKey'],
                 'secret' => $settings['secretAccessKey'],
-            ],
-        ];
+            ];
+        }
 
         try {
             $s3 = new S3Client($clientConfig);


### PR DESCRIPTION
This pull request makes configuring the AWS `storageConfig` settings much simpler.

The Cloudfront settings weren’t required already, and instead of requiring to pass defaults for `requestHeaders` and `storageType` these can now be omitted.

Credentials settings can now also be omitted and the AWS SDK then tries to get credentials via their [Credential Provider Chain](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials.html), similar how it already works for AWS S3 asset volume configuration.

```php
return [
    'storageConfig' => [
        'aws' => [
            'region' => getenv('AWS_REGION'),
            'bucket' => getenv('S3_BUCKET'),
            'folder' => 'imager',
        ],
    ],
    'storages' => ['aws'],
    'imagerUrl' => getenv('S3_BASE_URL').'imager/',
    'imagerSystemPath' => '@webroot/imager/',
];
```

```
AWS_PROFILE="craft3-prod"
AWS_REGION="eu-central-1"
S3_BUCKET="craft3-prod-ioeiz1"
S3_BASE_URL="https://${S3_BUCKET}.s3.amazonaws.com/"
```