### PR TITLE
Normalize path to imagerSystemPath returned from Settings model

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -2,6 +2,7 @@
 
 namespace aelvan\imager\models;
 
+use craft\helpers\FileHelper;
 use craft\base\Model;
 use Yii;
 
@@ -163,7 +164,7 @@ class Settings extends Model
     public function init()
     {
         // Have to set this here cause Yii::getAlias can't be used in default value
-        $this->imagerSystemPath = Yii::getAlias($this->imagerSystemPath);
+        $this->imagerSystemPath = FileHelper::normalizePath(Yii::getAlias($this->imagerSystemPath));
         $this->suppressExceptions = !\Craft::$app->getConfig()->general->devMode;
     }
 }


### PR DESCRIPTION
This fixes an issue where the destination folder on remote storage (at least AWS) includes the full local path to the transformed file.