### PR TITLE
Update ImgixTransformedImageModel.php

### DIFF
--- a/src/models/ImgixTransformedImageModel.php
+++ b/src/models/ImgixTransformedImageModel.php
@@ -78,7 +78,7 @@ class ImgixTransformedImageModel implements TransformedImageInterface
         $this->size = 0;
 
         if ($imageUrl !== null) {
-            $this->url = $imageUrl;
+            $this->url = utf8_decode(urldecode($imageUrl));
         }
 
         $this->width = 0;


### PR DESCRIPTION
Some paths and filenames containing non-ascii chars such as "åäö" got incorrect encoded urls. This line fixes that. Although, since I'm not too familiar with php - it might be concidered a bad solution. 